### PR TITLE
Fix segfaults due to double frees

### DIFF
--- a/oauth.c
+++ b/oauth.c
@@ -671,8 +671,9 @@ static void oauth_set_debug_info(php_so_object *soo) {
 		debugInfo = &soo->debugArr;
 
 		if (Z_TYPE_P(debugInfo) == IS_UNDEF) {
-			array_init(debugInfo);
+			zval_ptr_dtor(debugInfo);
 		}
+		array_init(debugInfo);
 
 		if(soo->debug_info->sbs) {
 			add_assoc_string(debugInfo, "sbs", ZSTR_VAL(soo->debug_info->sbs));

--- a/oauth.c
+++ b/oauth.c
@@ -670,7 +670,7 @@ static void oauth_set_debug_info(php_so_object *soo) {
 	if (soo->debug_info) {
 		debugInfo = &soo->debugArr;
 
-		if (Z_TYPE_P(debugInfo) == IS_UNDEF) {
+		if (Z_TYPE_P(debugInfo) != IS_UNDEF) {
 			zval_ptr_dtor(debugInfo);
 		}
 		array_init(debugInfo);

--- a/oauth.c
+++ b/oauth.c
@@ -672,8 +672,6 @@ static void oauth_set_debug_info(php_so_object *soo) {
 
 		if (Z_TYPE_P(debugInfo) == IS_UNDEF) {
 			array_init(debugInfo);
-		} else {
-			FREE_ARGS_HASH(HASH_OF(debugInfo));
 		}
 
 		if(soo->debug_info->sbs) {

--- a/php_oauth.h
+++ b/php_oauth.h
@@ -304,7 +304,6 @@ zend_string *oauth_generate_sig_base(php_so_object *soo, const char *http_method
 		if(t) { \
 			zend_string *tmp, *s_zstr = zend_string_init((s).c, (s).len, 0); \
 			tmp = php_trim(s_zstr, NULL, 0, 3); \
-			zend_string_addref(tmp); \
 			add_assoc_string((a), k, ZSTR_VAL(tmp)); \
 			zend_string_release(tmp); \
 			zend_string_release(s_zstr); \

--- a/php_oauth.h
+++ b/php_oauth.h
@@ -304,9 +304,10 @@ zend_string *oauth_generate_sig_base(php_so_object *soo, const char *http_method
 		if(t) { \
 			zend_string *tmp, *s_zstr = zend_string_init((s).c, (s).len, 0); \
 			tmp = php_trim(s_zstr, NULL, 0, 3); \
+			zend_string_addref(tmp); \
 			add_assoc_string((a), k, ZSTR_VAL(tmp)); \
-			zend_string_free(tmp); \
-			zend_string_free(s_zstr); \
+			zend_string_release(tmp); \
+			zend_string_release(s_zstr); \
 		} else { \
 			add_assoc_string((a), k, (s).c); \
 		} \

--- a/provider.c
+++ b/provider.c
@@ -164,7 +164,7 @@ static void oauth_provider_check_required_params(HashTable *required_params, Has
 	zend_hash_internal_pointer_reset_ex(missing_params, &paramhpos);
 	do {
 		if(zend_hash_get_current_key_ex(required_params, &key, &num_key, &hpos) == HASH_KEY_IS_STRING) {
-			if((dest_entry = zend_hash_find(params, key)) != NULL) {
+			if((dest_entry = zend_hash_find(params, key)) == NULL) {
 				ZVAL_STRING(&param, ZSTR_VAL(key));
 				zend_hash_next_index_insert(missing_params, &param);
 			}

--- a/provider.c
+++ b/provider.c
@@ -45,7 +45,7 @@ static int oauth_provider_set_default_required_params(HashTable *ht) /* {{{ */
 	do {
 		zval tmp;
 		ZVAL_NULL(&tmp);
-		if(zend_hash_str_add(ht, required_params[idx], strlen(required_params[idx]) + 1, &tmp) == NULL) {
+		if(zend_hash_str_add(ht, required_params[idx], strlen(required_params[idx]), &tmp) == NULL) {
 			return FAILURE;
 		}
 		++idx;
@@ -106,6 +106,7 @@ static void oauth_provider_apply_custom_param(HashTable *ht, HashTable *custom) 
 			if (IS_NULL == Z_TYPE_P(entry)) {
 				zend_hash_del(ht, key);
 			} else {
+				Z_ADDREF_P(entry);
 				zend_hash_update(ht, key, entry);
 			}
 		}
@@ -652,7 +653,7 @@ SOP_METHOD(setRequestTokenPath)
 /* {{{ proto void OAuthProvider::checkOAuthRequest([string url [, string request_method]]) */
 SOP_METHOD(checkOAuthRequest)
 {
-	zval *retval = NULL, *param, *pthis, *token_secret = NULL, *consumer_secret, *req_signature, *sig_method, rv;
+	zval *retval = NULL, *param, *pthis, *token_secret = NULL, *consumer_secret, *req_signature, *sig_method = NULL, rv;
 	oauth_sig_context *sig_ctx = NULL;
 	php_oauth_provider *sop;
 	ulong missing_param_count = 0, mp_count = 1;
@@ -731,7 +732,7 @@ SOP_METHOD(checkOAuthRequest)
 
 	sig_method = zend_read_property(Z_OBJCE_P(pthis), pthis, OAUTH_PROVIDER_SIGNATURE_METHOD, sizeof(OAUTH_PROVIDER_SIGNATURE_METHOD) - 1, 1, &rv);
 	do {
-		if (sig_method && Z_STRLEN_P(sig_method)) {
+		if (sig_method && (Z_TYPE_P(sig_method) == IS_STRING) && Z_STRLEN_P(sig_method)) {
 			sig_ctx = oauth_create_sig_context(Z_STRVAL_P(sig_method));
 			if (OAUTH_SIGCTX_TYPE_NONE!=sig_ctx->type) {
 				break;


### PR DESCRIPTION
 The array value ref count(s) is not correctly incremented when the value is copied to different arrays.