### PR TITLE
Don't copy string with extra trailing byte.

### DIFF
--- a/oauth.c
+++ b/oauth.c
@@ -570,10 +570,10 @@ zend_string *oauth_generate_sig_base(php_so_object *soo, const char *http_method
 	smart_string sbuf = {0};
 
 	urlparts = php_url_parse_ex(uri, strlen(uri));
-	php_strtolower(urlparts->scheme, strlen(urlparts->scheme));
-	php_strtolower(urlparts->host, strlen(urlparts->host));
 
 	if (urlparts) {
+		php_strtolower(urlparts->scheme, strlen(urlparts->scheme));
+		php_strtolower(urlparts->host, strlen(urlparts->host));
 		if (!urlparts->host || !urlparts->scheme) {
 			soo_handle_error(soo, OAUTH_ERR_INTERNAL_ERROR, "Invalid url when trying to build base signature string", NULL, NULL);
 			php_url_free(urlparts);

--- a/provider.c
+++ b/provider.c
@@ -860,11 +860,11 @@ SOP_METHOD(setParam)
 	sop = fetch_sop_object(pthis);
 
 	if (!param_val) {
-		RETURN_BOOL(SUCCESS == zend_hash_str_del(sop->custom_params, param_key, param_key_len+1) ? IS_TRUE : IS_FALSE);
+		RETURN_BOOL(SUCCESS == zend_hash_str_del(sop->custom_params, param_key, param_key_len) ? IS_TRUE : IS_FALSE);
 	} else {
 		Z_ADDREF_P(param_val);
 
-		RETURN_BOOL(NULL != zend_hash_str_add(sop->custom_params, param_key, param_key_len+1, param_val) ? IS_TRUE : IS_FALSE);
+		RETURN_BOOL(NULL != zend_hash_str_add(sop->custom_params, param_key, param_key_len, param_val) ? IS_TRUE : IS_FALSE);
 	}
 }
 /* }}} */

--- a/tests/bug16946.phpt
+++ b/tests/bug16946.phpt
@@ -42,20 +42,20 @@ array(2) {
   string(4) "4567"
 }
 string(%d) "GET /test HTTP/%f
-Host: 127.0.0.1:12342
 User-Agent: PECL-OAuth/%f%s
+Host: 127.0.0.1:12342
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 
 GET /some_url_that_goes_nowhere_and_could_be_very_long.html?bla=bla&mekker=mekker HTTP/%f
-Host: 127.0.0.1:12342
 User-Agent: PECL-OAuth/%f%s
+Host: 127.0.0.1:12342
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 
 GET /some_other_url.html HTTP/%f
-Host: 127.0.0.1:12342
 User-Agent: PECL-OAuth/%f%s
+Host: 127.0.0.1:12342
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 

--- a/tests/oauthprovider_007.phpt
+++ b/tests/oauthprovider_007.phpt
@@ -1,0 +1,30 @@
+--TEST--
+OauthProvider checkOauthRequest
+--FILE--
+<?php
+require 'oauth.inc';
+
+try {
+    $create_params = creationParams();
+    $create_params['should_remove_this_param'] = 'abc';
+
+    $provider = new OAuthProvider($create_params);
+    $provider->consumerHandler(function() {
+	return OAUTH_OK;
+    });
+    $provider->timestampNonceHandler(function() {
+    	return OAUTH_OK;
+    });
+    $provider->tokenHandler(function() {
+    	return OAUTH_OK;
+    });
+    $provider->setParam('should_remove_this_param', NULL);
+
+    $provider->checkOAuthRequest("http://localhost/request_token.php", OAUTH_HTTP_METHOD_GET);
+
+} catch (OAuthException $E) {
+    echo OAuthProvider::reportProblem($E);
+}
+
+--EXPECT--
+oauth_problem=signature_invalid&debug_sbs=GET&http%3A%2F%2Flocalhost%2Frequest_token.php&oauth_consumer_key%3Dapi_key%26oauth_nonce%3DraNdOM%26oauth_signature_method%3DHMAC-SHA1%26oauth_timestamp%3D12345%26oauth_token%3Da_good_token

--- a/tests/overflow_redir.phpt
+++ b/tests/overflow_redir.phpt
@@ -41,14 +41,14 @@ array(2) {
   string(4) "4567"
 }
 string(%d) "GET /test HTTP/%f
-Host: 127.0.0.1:12342
 User-Agent: PECL-OAuth/%f%s
+Host: 127.0.0.1:12342
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 
 GET /aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa HTTP/%f
-Host: 127.0.0.1:12342
 User-Agent: PECL-OAuth/%f%s
+Host: 127.0.0.1:12342
 Accept: */*
 Authorization: OAuth oauth_consumer_key="1234",oauth_signature_method="HMAC-SHA1",oauth_nonce="%s.%d",oauth_timestamp="%d",oauth_version="1.0",oauth_signature="%s"
 


### PR DESCRIPTION
zend hash tables compares the string exactly including the length
so "currency\0" does not match "currency"
find the element