### PR TITLE
Update provider.c

### DIFF
--- a/provider.c
+++ b/provider.c
@@ -810,7 +810,7 @@ SOP_METHOD(checkOAuthRequest)
 
 		req_signature = zend_read_property(Z_OBJCE_P(pthis), pthis, OAUTH_PROVIDER_SIGNATURE, sizeof(OAUTH_PROVIDER_SIGNATURE) - 1, 1, &rv);
 		if (!signature || !Z_STRLEN_P(req_signature) || strcmp(ZSTR_VAL(signature), Z_STRVAL_P(req_signature))) {
-			soo_handle_error(NULL, OAUTH_INVALID_SIGNATURE, "Signatures do not match", NULL, ZSTR_VAL(sbs));
+			soo_handle_error(NULL, OAUTH_INVALID_SIGNATURE, "Signatures do not match", NULL, NULL);
 		}
 
 		zend_string_release(sbs);


### PR DESCRIPTION
sbs might be null there as per the check on line 801, so we can't use it outside that check